### PR TITLE
Fixed missing trim on rows & added more unit tests

### DIFF
--- a/BranchDetails.Action.Tests/Data/CoreTests.cs
+++ b/BranchDetails.Action.Tests/Data/CoreTests.cs
@@ -1,0 +1,216 @@
+﻿/*
+ * This file is part of Branch Details <https://github.com/StevenJDH/branch-details>.
+ * Copyright (C) 2024 Steven Jenkins De Haro.
+ *
+ * Branch Details is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Branch Details is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Branch Details.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+// Ignore Spelling: Env
+
+using BranchDetails.Action.Data;
+using static BranchDetails.Action.Data.Core;
+
+namespace BranchDetails.Action.Tests.Data;
+
+[TestFixture]
+public class CoreTests
+{
+    private readonly string _outputFile = Path.Combine(Directory.GetCurrentDirectory(), "output.txt");
+    private readonly string _envFile = Path.Combine(Directory.GetCurrentDirectory(), "env.txt");
+    private readonly string _summaryFile = Path.Combine(Directory.GetCurrentDirectory(), "summary.txt");
+
+    [Test, Description("Should contain only expected statuses for exit codes.")]
+    public void Should_ContainOnlyExpectedStatuses_ForExitCodes()
+    {
+        ExitCode[] expectedExitCodes = [ExitCode.Success, ExitCode.Failure];
+
+        var exitCodes = Enum.GetValues(typeof(ExitCode));
+
+        Assert.That(exitCodes, Is.EquivalentTo(expectedExitCodes));
+    }
+
+    [Test, Description("Should match correct exit code for each status.")]
+    public void Should_MatchCorrectExitCode_ForEachStatus()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That((int)ExitCode.Success, Is.EqualTo(0));
+            Assert.That((int)ExitCode.Failure, Is.EqualTo(1));
+        });
+    }
+
+    [Test, Description("Should return value when requested optional by default input is defined.")]
+    public void Should_ReturnValue_When_RequestedOptionalByDefaultInputIsDefined()
+    {
+        Environment.SetEnvironmentVariable("INPUT_EXPORT-VARIABLES", "true");
+
+        string input = Core.GetInput("export-variables");
+
+        Assert.That(input, Is.EqualTo("true"));
+
+        Environment.SetEnvironmentVariable("INPUT_EXPORT-VARIABLES", null);
+    }
+
+    [Test, Description("Should return empty value when requested optional input is not defined.")]
+    public void Should_ReturnEmptyValue_When_RequestedOptionalInputIsNotDefined()
+    {
+        string input = Core.GetInput("foobar", new InputOptions(Required: false));
+
+        Assert.That(input, Is.Empty);
+    }
+
+    [Test, Description("Should throw ArgumentNullException when requested required input is not defined.")]
+    public void Should_ThrowArgumentNullException_When_RequestedRequiredInputIsNotDefined()
+    {
+        const string expectedMessage = "Required input not supplied. (Parameter 'foobar')";
+
+        Assert.That(() => Core.GetInput("foobar", new InputOptions(Required: true)), Throws.ArgumentNullException
+            .With.Message.EqualTo(expectedMessage));
+    }
+
+    [TestCase("  true  ", true, "true")]
+    [TestCase("  true  ", false, "  true  ")]
+    [TestCase(null, true, "")]
+    [TestCase(null, false, "")]
+    [Description("Should conditionally trim value when setting TrimWhitespace option.")]
+    public void Should_ConditionallyTrimValue_When_SettingTrimWhitespaceOption(string? value, bool trimWhitespace, string expectedResult)
+    {
+        Environment.SetEnvironmentVariable("INPUT_EXPORT-VARIABLES", value);
+
+        string input = Core.GetInput("export-variables", new InputOptions(TrimWhitespace: trimWhitespace));
+
+        Assert.That(input, Is.EqualTo(expectedResult));
+
+        Environment.SetEnvironmentVariable("INPUT_EXPORT-VARIABLES", null);
+    }
+
+    [Test, Description("Should set GitHub Output file for provided key value pairs.")]
+    public async Task Should_SetGitHubOutputFile_ForProvidedKeyValuePairs()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_OUTPUT", _outputFile);
+        await File.Create(_outputFile).DisposeAsync();
+        IReadOnlyList<string> expectedRows = ["test", "foobar"];
+        string expectedOutputData = $"test=foobar{Environment.NewLine}";
+
+        var result = await Core.SetOutputAsync(" test ", " foobar ");
+        string outputData = await File.ReadAllTextAsync(_outputFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(expectedRows));
+            Assert.That(outputData, Is.EqualTo(expectedOutputData));
+        });
+
+        Environment.SetEnvironmentVariable("GITHUB_OUTPUT", null);
+        File.Delete(_outputFile);
+    }
+
+    [Test, Description("Should throw ArgumentException when GitHub Output file path is not defined.")]
+    public void Should_ThrowArgumentException_When_GitHubOutputFilePathIsNotDefined()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_OUTPUT", null);
+        const string expectedMessage = "Unable to find environment variable for file command OUTPUT (GITHUB_OUTPUT).";
+
+        Assert.That(async () => await Core.SetOutputAsync("test", "foobar"), Throws.ArgumentException
+            .With.Message.EqualTo(expectedMessage));
+    }
+
+    [Test, Description("Should throw FileNotFoundException when GitHub Output file is missing.")]
+    public void Should_ThrowFileNotFoundException_When_GitHubOutputFileIsMissing()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_OUTPUT", _outputFile);
+        string expectedMessage = $"Missing file at path: '{_outputFile}' for file command OUTPUT (GITHUB_OUTPUT).";
+
+        Assert.That(async () => await Core.SetOutputAsync("test", "foobar"), Throws.TypeOf<FileNotFoundException>()
+            .With.Message.EqualTo(expectedMessage));
+    }
+
+    [Test, Description("Should set GitHub Env file for provided key value pairs.")]
+    public async Task Should_SetGitHubEnvFile_ForProvidedKeyValuePairs()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_ENV", _envFile);
+        await File.Create(_envFile).DisposeAsync();
+        IReadOnlyList<string> expectedRows = ["test", "foobar"];
+        string expectedEnvData = $"test=foobar{Environment.NewLine}";
+
+        var result = await Core.ExportVariableAsync(" test ", " foobar ");
+        string envData = await File.ReadAllTextAsync(_envFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(expectedRows));
+            Assert.That(envData, Is.EqualTo(expectedEnvData));
+        });
+
+        Environment.SetEnvironmentVariable("GITHUB_ENV", null);
+        File.Delete(_envFile);
+    }
+
+    [Test, Description("Should throw ArgumentException when GitHub Env file path is not defined.")]
+    public void Should_ThrowArgumentException_When_GitHubEnvFilePathIsNotDefined()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_ENV", null);
+        const string expectedMessage = "Unable to find environment variable for file command ENV (GITHUB_ENV).";
+
+        Assert.That(async () => await Core.ExportVariableAsync("test", "foobar"), Throws.ArgumentException
+            .With.Message.EqualTo(expectedMessage));
+    }
+
+    [Test, Description("Should throw FileNotFoundException when GitHub Env file is missing.")]
+    public void Should_ThrowFileNotFoundException_When_GitHubEnvFileIsMissing()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_ENV", _envFile);
+        string expectedMessage = $"Missing file at path: '{_envFile}' for file command ENV (GITHUB_ENV).";
+
+        Assert.That(async () => await Core.ExportVariableAsync("test", "foobar"), Throws.TypeOf<FileNotFoundException>()
+            .With.Message.EqualTo(expectedMessage));
+    }
+
+    [Test, Description("Should set GitHub Step Summary file for provided markdown content.")]
+    public async Task Should_SetGitHubStepSummaryFile_ForProvidedMarkdownContent()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", _summaryFile);
+        await File.Create(_summaryFile).DisposeAsync();
+        string expectedSummaryData = $"foobar{Environment.NewLine}";
+
+        await Core.SetStepSummaryAsync(" foobar ");
+        string summaryData = await File.ReadAllTextAsync(_summaryFile);
+
+        Assert.That(summaryData, Is.EqualTo(expectedSummaryData));
+
+        Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", null);
+        File.Delete(_summaryFile);
+    }
+
+    [Test, Description("Should throw ArgumentException when GitHub Step Summary file path is not defined.")]
+    public void Should_ThrowArgumentException_When_GitHubStepSummaryFilePathIsNotDefined()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", null);
+        const string expectedMessage = "Unable to find environment variable for file command STEP_SUMMARY (GITHUB_STEP_SUMMARY).";
+
+        Assert.That(async () => await Core.SetStepSummaryAsync("foobar"), Throws.ArgumentException
+            .With.Message.EqualTo(expectedMessage));
+    }
+
+    [Test, Description("Should throw FileNotFoundException when GitHub Step Summary file is missing.")]
+    public void Should_ThrowFileNotFoundException_When_GitHubStepSummaryFileIsMissing()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", _summaryFile);
+        string expectedMessage = $"Missing file at path: '{_summaryFile}' for file command STEP_SUMMARY (GITHUB_STEP_SUMMARY).";
+
+        Assert.That(async () => await Core.SetStepSummaryAsync("foobar"), Throws.TypeOf<FileNotFoundException>()
+            .With.Message.EqualTo(expectedMessage));
+    }
+}

--- a/BranchDetails.Action.Tests/Data/SummaryTests.cs
+++ b/BranchDetails.Action.Tests/Data/SummaryTests.cs
@@ -63,9 +63,9 @@ public class SummaryTests
 
         var exception = Assert.Throws<ArgumentException>(() => summary.AppendHeader("Test Title", level));
 
-        Assert.That(exception, Is.Not.Null);
         Assert.Multiple(() =>
         {
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
             Assert.That(exception.InnerException, Is.Null);
         });
@@ -113,9 +113,9 @@ public class SummaryTests
 
         var exception = Assert.Throws<ArgumentException>(() => summary.AppendTable(columns, rows));
 
-        Assert.That(exception, Is.Not.Null);
         Assert.Multiple(() =>
         {
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
             Assert.That(exception.InnerException, Is.Null);
         });
@@ -130,10 +130,10 @@ public class SummaryTests
         string expectedMessage = "At least one column is required. (Parameter 'columns')";
 
         var exception = Assert.Throws<ArgumentException>(() => summary.AppendTable(columns, rows));
-
-        Assert.That(exception, Is.Not.Null);
+        
         Assert.Multiple(() =>
         {
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
             Assert.That(exception.InnerException, Is.Null);
         });
@@ -149,9 +149,9 @@ public class SummaryTests
 
         var exception = Assert.Throws<ArgumentException>(() => summary.AppendTable(columns, rows));
 
-        Assert.That(exception, Is.Not.Null);
         Assert.Multiple(() =>
         {
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
             Assert.That(exception.InnerException, Is.Null);
         });
@@ -166,10 +166,10 @@ public class SummaryTests
         string expectedMessage = "At least one row is required. (Parameter 'rows')";
 
         var exception = Assert.Throws<ArgumentException>(() => summary.AppendTable(columns, rows));
-
-        Assert.That(exception, Is.Not.Null);
+        
         Assert.Multiple(() =>
         {
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
             Assert.That(exception.InnerException, Is.Null);
         });
@@ -185,9 +185,9 @@ public class SummaryTests
 
         var exception = Assert.Throws<ArgumentException>(() => summary.AppendTable(columns, rows));
 
-        Assert.That(exception, Is.Not.Null);
         Assert.Multiple(() =>
         {
+            Assert.That(exception, Is.Not.Null);
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
             Assert.That(exception.InnerException, Is.Null);
         });

--- a/BranchDetails.Action.Tests/Extensions/ConfigurationBuilderExtensionsTests.cs
+++ b/BranchDetails.Action.Tests/Extensions/ConfigurationBuilderExtensionsTests.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * This file is part of Branch Details <https://github.com/StevenJDH/branch-details>.
+ * Copyright (C) 2024 Steven Jenkins De Haro.
+ *
+ * Branch Details is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Branch Details is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Branch Details.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using BranchDetails.Action.Extensions;
+using Microsoft.Extensions.Configuration;
+
+namespace BranchDetails.Action.Tests.Extensions;
+
+[TestFixture]
+public class ConfigurationBuilderExtensionsTests
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        // Switches logic to local mode to activate the logic for loading secrets. 
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+    }
+
+    [Test, Description("Should load any secrets available for local development.")]
+    public void Should_LoadAnySecretsAvailable_ForLocalDevelopment()
+    {
+        const string expectedKey = "test";
+        const string expectedValue = "foobar";
+        IConfiguration configRoot = new ConfigurationBuilder()
+            .AddInMemoryCollection([new KeyValuePair<string, string?>(expectedKey, expectedValue)])
+            .AddGitHubActionSecrets() // No secrets to load in pipeline, but we ensure it works anyway.
+            .Build();
+
+        string? testConfig = configRoot.GetSection(expectedKey).Value;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configRoot.AsEnumerable().Count(), Is.GreaterThanOrEqualTo(1));
+            Assert.That(testConfig, Is.EqualTo(expectedValue));
+        });
+    }
+}

--- a/BranchDetails.Action.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/BranchDetails.Action.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -30,7 +30,7 @@ public class ServiceCollectionExtensionsTests
     private readonly string _outputFile = Path.Combine(Directory.GetCurrentDirectory(), "output.txt");
 
     [OneTimeSetUp]
-    public void SetUp()
+    public void OneTimeSetUp()
     {
         File.Create(_outputFile).Dispose();
         Environment.SetEnvironmentVariable("GITHUB_REF", "refs/heads/test");
@@ -43,7 +43,7 @@ public class ServiceCollectionExtensionsTests
     }
 
     [OneTimeTearDown]
-    public void TearDown()
+    public void OneTimeTearDown()
     {
         File.Delete(_outputFile);
     }
@@ -55,10 +55,14 @@ public class ServiceCollectionExtensionsTests
         var provider = services
             .AddGitHubActionServices()
             .BuildServiceProvider();
+
         var ctx = provider.GetService<Context>();
 
-        Assert.That(ctx, Is.Not.Null);
-        Assert.That(ctx, Is.InstanceOf<Context>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx, Is.Not.Null);
+            Assert.That(ctx, Is.InstanceOf<Context>());
+        });
     }
 
     [Test, Description("Should add action inputs for dependency injection.")]
@@ -68,10 +72,14 @@ public class ServiceCollectionExtensionsTests
         var provider = services
             .AddGitHubActionServices()
             .BuildServiceProvider();
+
         var inputs = provider.GetService<ActionInputs>();
 
-        Assert.That(inputs, Is.Not.Null);
-        Assert.That(inputs, Is.InstanceOf<ActionInputs>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(inputs, Is.Not.Null);
+            Assert.That(inputs, Is.InstanceOf<ActionInputs>());
+        });
     }
 
     [Test, Description("Should add GitHub client for dependency injection.")]
@@ -81,10 +89,14 @@ public class ServiceCollectionExtensionsTests
         var provider = services
             .AddGitHubActionServices()
             .BuildServiceProvider();
+
         var client = provider.GetService<GitHubClient>();
 
-        Assert.That(client, Is.Not.Null);
-        Assert.That(client, Is.InstanceOf<GitHubClient>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(client, Is.Not.Null);
+            Assert.That(client, Is.InstanceOf<GitHubClient>());
+        });
     }
 
     [Test, Description("Should add GitHub Service for dependency injection.")]
@@ -94,10 +106,14 @@ public class ServiceCollectionExtensionsTests
         var provider = services
             .AddGitHubActionServices()
             .BuildServiceProvider();
+
         var github = provider.GetService<IGitHubService>();
 
-        Assert.That(github, Is.Not.Null);
-        Assert.That(github, Is.InstanceOf<IGitHubService>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(github, Is.Not.Null);
+            Assert.That(github, Is.InstanceOf<IGitHubService>());
+        });
     }
 
     [Test, Description("Should add branch name processor for dependency injection.")]
@@ -108,9 +124,13 @@ public class ServiceCollectionExtensionsTests
             .AddLogging()
             .AddGitHubActionServices()
             .BuildServiceProvider();
+
         var processor = provider.GetService<BranchDetailsProcessor>();
 
-        Assert.That(processor, Is.Not.Null);
-        Assert.That(processor, Is.InstanceOf<BranchDetailsProcessor>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(processor, Is.Not.Null);
+            Assert.That(processor, Is.InstanceOf<BranchDetailsProcessor>());
+        });
     }
 }

--- a/BranchDetails.Action.Tests/ProgramTests.cs
+++ b/BranchDetails.Action.Tests/ProgramTests.cs
@@ -16,21 +16,27 @@
  * along with Branch Details.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-using BranchDetails.Action.Data;
-using GitHub;
+using System.Reflection;
 
-namespace BranchDetails.Action.Services;
+namespace BranchDetails.Action.Tests;
 
-internal class GitHubService(GitHubClient github, Context context) : IGitHubService
+[TestFixture]
+internal class ProgramTests
 {
-    private readonly GitHubClient _github = github;
-    private readonly string _repoOwner = context.RepositoryOwner;
-    private readonly string _repo = context.Repository.Split("/")[^1];
-
-    /// <inheritdoc />
-    public async ValueTask<string?> GetDefaultBranchAsync()
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
     {
-        var response = await _github.Repos[_repoOwner][_repo].GetAsync();
-        return response?.DefaultBranch;
+        Environment.SetEnvironmentVariable("INPUT_GITHUB-TOKEN", null);
+    }
+
+    [Test, Description("Should load and throw ArgumentException when no access token is provided.")]
+    public void Should_LoadAndThrowArgumentException_When_NoAccessTokenIsProvided()
+    {
+        var program = typeof(Program).GetTypeInfo();
+        var mainMethod = program.DeclaredMethods.Single(m => m.Name == "<Main>$");
+        const string expectedMessage = "accessToken";
+
+        Assert.That(async () => await (Task<int>)mainMethod.Invoke(null, [Array.Empty<string>()])!, Throws.ArgumentException
+            .With.Message.EqualTo(expectedMessage));
     }
 }

--- a/BranchDetails.Action.Tests/Services/GitHubServiceTests.cs
+++ b/BranchDetails.Action.Tests/Services/GitHubServiceTests.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * This file is part of Branch Details <https://github.com/StevenJDH/branch-details>.
+ * Copyright (C) 2024 Steven Jenkins De Haro.
+ *
+ * Branch Details is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Branch Details is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Branch Details.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using BranchDetails.Action.Data;
+using BranchDetails.Action.Services;
+using GitHub;
+using GitHub.Models;
+using GitHub.Octokit.Client;
+using GitHub.Octokit.Client.Authentication;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Kiota.Abstractions;
+
+namespace BranchDetails.Action.Tests.Services;
+
+[TestFixture]
+public class GitHubServiceTests
+{
+    private readonly JsonSerializerOptions _githubSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+[OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_REPOSITORY_OWNER", "StevenJDH");
+        Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", "StevenJDH/branch-details");
+    }
+
+    [Test, Description("Should return default branch name when making a request.")]
+    public async Task Should_ReturnDefaultBranchName_When_MakingARequest()
+    {
+        // Arrange
+        var ctx = new Context();
+        var tokenProvider = new BaseBearerTokenAuthenticationProvider(new TokenProvider("123456"));
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        using var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+        IRequestAdapter requestAdapter = RequestAdapter.Create(tokenProvider, httpClient);
+        var service = new GitHubService(new GitHubClient(requestAdapter), ctx);
+        string jsonResponse = JsonSerializer.Serialize(new FullRepository
+        {
+            DefaultBranch = "foobar"
+        }, _githubSerializerOptions);
+        var httpResponseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(jsonResponse, Encoding.UTF8, MediaTypeNames.Application.Json)
+        };
+        const string expectedBranchName = "foobar";
+
+        mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(httpResponseMessage);
+
+        // Act
+        string? branchName = await service.GetDefaultBranchAsync();
+
+        // Assert
+        Assert.That(branchName, Is.EqualTo(expectedBranchName));
+    }
+}

--- a/BranchDetails.Action/BranchDetails.Action.csproj
+++ b/BranchDetails.Action/BranchDetails.Action.csproj
@@ -11,12 +11,12 @@
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<!-- Set to false to see full analysis details. Default is true. -->
 		<TrimmerSingleWarn>true</TrimmerSingleWarn>
-		<Description>......</Description>
+		<Description>A GitHub action that exposes information about branches, tags, and related concepts to simplify automation activities.</Description>
 		<Copyright>Copyright © 2024</Copyright>
 		<Authors>Steven Jenkins De Haro</Authors>
-		<Version>1.0.0</Version>
-		<AssemblyVersion>1.0.0.24101</AssemblyVersion>
-		<FileVersion>1.0.0.24101</FileVersion>
+		<Version>1.0.1</Version>
+		<AssemblyVersion>1.0.1.24102</AssemblyVersion>
+		<FileVersion>1.0.1.24102</FileVersion>
 		<RepositoryUrl>https://github.com/StevenJDH/branch-details</RepositoryUrl>
 		<NoWarn>CA2254</NoWarn>
 		<UserSecretsId>52fa3310-d8b3-4307-90e8-d9135be0b971</UserSecretsId>
@@ -34,8 +34,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GitHub.Octokit.SDK" Version="0.0.28" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="GitHub.Octokit.SDK" Version="0.0.29" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<!-- Exposes internal classes to test project and Moq. -->
 		<InternalsVisibleTo Include="$(AssemblyName).Tests;DynamicProxyGenAssembly2" />

--- a/BranchDetails.Action/Data/Core.cs
+++ b/BranchDetails.Action/Data/Core.cs
@@ -75,8 +75,12 @@ internal static class Core
     /// <returns>A readonly list of passed arguments.</returns>
     public static async ValueTask<IReadOnlyList<string>> SetOutputAsync(string name, string value)
     {
-        await IssueFileCommand("OUTPUT", $"{name.Trim()}={value.Trim()}");
-        return [name, value];
+        string outputName = name.Trim();
+        string outputValue = value.Trim();
+
+        await IssueFileCommand("OUTPUT", $"{outputName}={outputValue}");
+
+        return [outputName, outputValue];
     }
 
     /// <summary>
@@ -87,8 +91,12 @@ internal static class Core
     /// <returns>A readonly list of passed arguments.</returns>
     public static async ValueTask<IReadOnlyList<string>> ExportVariableAsync(string name, string value)
     {
-        await IssueFileCommand("ENV", $"{name.Trim()}={value.Trim()}");
-        return [name, value];
+        string envName = name.Trim();
+        string envValue = value.Trim();
+
+        await IssueFileCommand("ENV", $"{envName}={envValue}");
+        
+        return [envName, envValue];
     }
 
     public static async ValueTask SetStepSummaryAsync(string markdown)

--- a/BranchDetails.Action/Program.cs
+++ b/BranchDetails.Action/Program.cs
@@ -28,7 +28,7 @@ using var host = Host.CreateDefaultBuilder(args)
     .Build();
 
 Console.WriteLine($"""
-    Branch Details 1.0.0.24101
+    Branch Details 1.0.1.24102
     Copyright (C) 2024{(DateTime.Now.Year.Equals(2024) ? "" : $"-{DateTime.Now.Year}")} Steven Jenkins De Haro
     
     """);

--- a/BranchDetails.Action/Validators/SemVerValidator.cs
+++ b/BranchDetails.Action/Validators/SemVerValidator.cs
@@ -16,6 +16,9 @@
  * along with Branch Details.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+// Ignore Spelling: Sem Ver Validator Versioning
+
 using System.Text.RegularExpressions;
 
 namespace BranchDetails.Action.Validators;

--- a/action.yml
+++ b/action.yml
@@ -76,4 +76,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/stevenjdh/branch-details:1.0.0'
+  image: 'docker://ghcr.io/stevenjdh/branch-details:1.0.1'


### PR DESCRIPTION
## Description
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? List any dependencies that are required for this change. -->
This pull request fixes a minor issue with trim not applied to output/env markdown rows, and adds additional unit tests. It also updates dependencies.

Dependencies:
* octokit/dotnet-sdk

## Does this introduce a breaking change?
<!-- Mark only one box with an "x". -->
- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?
<!-- Mark the box that applies to this PR with an "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## How has this been tested?
<!-- Describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration. -->
* Locally
* Unit tests

Test Configuration:
* SDK version: 8x
* octokit/dotnet-sdk version: 0.0.29

## Checklist:
<!-- Put an "x" in the boxes that apply. -->
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
N/A